### PR TITLE
fix: critical bug in EnumProcesses buffer handling in get_system_pid_…

### DIFF
--- a/bindgen/python/src/chromium.rs
+++ b/bindgen/python/src/chromium.rs
@@ -12,8 +12,8 @@ use decrypt_cookies_rs::{
 };
 use pyo3::{exceptions::PyValueError, prelude::*, types::PyList};
 use pyo3_async_runtimes::tokio::future_into_py;
-// use pyo3_stub_gen::derive::{gen_stub_pyclass, gen_stub_pymethods};
 
+// use pyo3_stub_gen::derive::{gen_stub_pyclass, gen_stub_pymethods};
 use crate::SameSite;
 
 macro_rules! chromiums {

--- a/bindgen/python/src/firefox.rs
+++ b/bindgen/python/src/firefox.rs
@@ -10,8 +10,8 @@ use decrypt_cookies_rs::{
 };
 use pyo3::{Bound, PyResult, Python, exceptions::PyValueError, pyclass, pymethods, types::PyList};
 use pyo3_async_runtimes::tokio::future_into_py;
-// use pyo3_stub_gen::derive::{gen_stub_pyclass, gen_stub_pymethods};
 
+// use pyo3_stub_gen::derive::{gen_stub_pyclass, gen_stub_pymethods};
 use crate::SameSite;
 
 macro_rules! firefoxs {

--- a/bindgen/python/src/lib.rs
+++ b/bindgen/python/src/lib.rs
@@ -1,7 +1,7 @@
 use decrypt_cookies_rs::browser::cookies::SameSite as SameSiteRs;
 use pyo3::prelude::*;
-// use pyo3_stub_gen::{define_stub_info_gatherer, derive::gen_stub_pyclass_enum};
 
+// use pyo3_stub_gen::{define_stub_info_gatherer, derive::gen_stub_pyclass_enum};
 use self::{
     chromium::*,
     firefox::*,

--- a/bindgen/python/src/safari.rs
+++ b/bindgen/python/src/safari.rs
@@ -6,8 +6,8 @@ use decrypt_cookies_rs::prelude::{
 };
 use pyo3::{Bound, PyResult, Python, exceptions::PyValueError, pyclass, pymethods};
 use pyo3_async_runtimes::tokio::future_into_py;
-// use pyo3_stub_gen::derive::{gen_stub_pyclass, gen_stub_pymethods};
 
+// use pyo3_stub_gen::derive::{gen_stub_pyclass, gen_stub_pymethods};
 use crate::SameSite;
 
 // #[gen_stub_pyclass]

--- a/crates/chromium-crypto/src/win/impersonate.rs
+++ b/crates/chromium-crypto/src/win/impersonate.rs
@@ -159,23 +159,21 @@ impl ImpersonateGuard {
     fn get_system_pid_list() -> Result<impl Iterator<Item = u32>> {
         let cap = 1024;
         let mut lpidprocess = Vec::with_capacity(cap);
-        let lpcbneeded = 0;
+        let mut lpcbneeded = 0u32;
+        let buffer_size = cap as u32 * 4;
 
         unsafe {
-            let mut var_name = cap as u32 * 4;
-            EnumProcesses(lpidprocess.as_mut_ptr(), lpcbneeded, &raw mut var_name)
+            EnumProcesses(lpidprocess.as_mut_ptr(), buffer_size, &raw mut lpcbneeded)
                 .context(error::CryptUnprotectDataSnafu)?;
             let c_processes = lpcbneeded as usize / size_of::<u32>();
             lpidprocess.set_len(c_processes);
         };
 
-        let filter = lpidprocess
-            .into_iter()
-            .filter(|&v| {
-                v != 0
-                    && Self::process_name_is(v, |n| n == "lsass.exe" || n == "winlogon.exe")
-                        .unwrap_or(false)
-            });
+        let filter = lpidprocess.into_iter().filter(|&v| {
+            v != 0
+                && Self::process_name_is(v, |n| n == "lsass.exe" || n == "winlogon.exe")
+                    .unwrap_or(false)
+        });
         Ok(filter)
     }
 


### PR DESCRIPTION
This bug made it impossible to use the library on v20 google chrome, no matter if the browser is running or the program running in admin mode.

I don't understand everything that's going on as this bug was found by opencode but adding these changes made it work.

Please add this fix, so that i dont have to have local changes, thanks!